### PR TITLE
도커 이미지 배포를 위한 yml 파일 추가 (#32)

### DIFF
--- a/backend/text-me/.github/workflows/deploy.yml
+++ b/backend/text-me/.github/workflows/deploy.yml
@@ -4,10 +4,9 @@ on:
   push:
     branches:
       - production
-  workflow_dispatch:
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,22 +17,17 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+          distribution: 'temurin'
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
-        shell: bash
-
-      - name: Build with Gradle
-        run: ./gradlew clean build
-        shell: bash
-
-      - name: Get current time
-        uses: 1466587594/get-current-time@v2
-        id: current-time
+      - name: SSH setting
+        uses: appleboy/ssh-action@master
         with:
-          format: YYYY-MM-DDTHH-mm-ss
-          utcOffset: "+09:00"
-
-      - name: Show Current Time
-        run: echo "CurrentTime=${{steps.current-time.outputs.formattedTime}}"
-        shell: bash
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USER_NAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          envs: GITHUB_SHA
+          scrips: |
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/text-me-docker-repo:tagname
+            docker tag ${{ secrets.DOCKERHUB_USERNAME }}/text-me-docker-repo:tagname
+            docker stop server
+            docker run -d --rm --name server -p 80:8080 text-me-docker

--- a/backend/text-me/.github/workflows/gradle.yml
+++ b/backend/text-me/.github/workflows/gradle.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build with jib
         run: |
           ./gradlew jib \
-          -Djib.to.image="zxcvb5434/devopstest"
+          -Djib.to.image="text-me-docker"
 
       - name: Docker push
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/text-me-docker-repo:tagname

--- a/backend/text-me/build.gradle
+++ b/backend/text-me/build.gradle
@@ -41,7 +41,7 @@ jib {
 		image = "eclipse-temurin:11-jre"
 	}
 	to {
-		image = "zxcvb5434/devopstest"
+		image = "text-me-docker"
 		tags = ["latest"]
 	}
 	container {


### PR DESCRIPTION
- 빌드 스크립트와 배포 스크립트를 다른 상황에서 trigger 되도록 분리하였습니다.
- 도커 이미지명을 변경하였습니다.