### PR TITLE
도커 이미지 빌드를 위한 인증 정보를 스크립트에 추가 (#65)

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Build with jib
         run: |
           ./gradlew jib \
+          -Djib.to.auth.username=${CI_REGISTRY_USER} \
+          -Djib.to.auth.password=${CI_REGISTRY_PASSWORD} \
           -Djib.to.image="text-me-docker"
 
       - name: Docker push

--- a/backend/text-me/Dockerfile
+++ b/backend/text-me/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk
+FROM openjdk:11
 ARG JAR_FILE="build/libs/*.jar"
 COPY ${JAR_FILE} text-me.jar
 ENTRYPOINT ["java","-jar","/text-me.jar"]


### PR DESCRIPTION
## 내용

- 이미지 빌드를 위한 인증 정보를 백엔드 빌드 스크립트에 추가해 주었습니다.
- 도커 파일의 자바 버전을 11로 수정하였습니다.