### PR TITLE
ImageIO가 스트림을 읽을수 없을시 예외처리 (#216)

### DIFF
--- a/backend/text-me/src/main/java/gifterz/textme/error/ErrorCode.java
+++ b/backend/text-me/src/main/java/gifterz/textme/error/ErrorCode.java
@@ -39,7 +39,9 @@ public enum ErrorCode {
     STATUS_EMPTY(400, "S001", "상태를 입력해주세요."),
 
     // File
-    INVALID_FILE_CONTENT(400, "F001", "적절하지 않은 파일 형식입니다.");
+    INVALID_FILE_CONTENT(400, "F001", "적절하지 않은 파일 형식입니다."),
+    Illegal_FILE(400, "F002", "업로드 할 수 없는 이미지입니다."),
+    FAIL_FILE_RESIZE(400, "F003", "파일 리사이즈에 실패했습니다.");
 
     private final int httpStatus;
     private final String code;

--- a/backend/text-me/src/main/java/gifterz/textme/s3Proxy/S3Service.java
+++ b/backend/text-me/src/main/java/gifterz/textme/s3Proxy/S3Service.java
@@ -3,7 +3,11 @@ package gifterz.textme.s3Proxy;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import gifterz.textme.s3Proxy.exception.InvalidFileContentException;
+import gifterz.textme.s3Proxy.exception.InvalidFileImage;
+import gifterz.textme.s3Proxy.exception.failFileResize;
+import io.jsonwebtoken.lang.Assert;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import marvin.image.MarvinImage;
 import org.apache.commons.lang3.ObjectUtils;
 import org.marvinproject.image.transform.scale.Scale;
@@ -19,8 +23,10 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.UUID;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class S3Service {
@@ -62,6 +68,9 @@ public class S3Service {
     MultipartFile resizeImage(String fileName, String fileFormatName, MultipartFile originalImage) {
         try {
             BufferedImage image = ImageIO.read(originalImage.getInputStream());
+            if (image == null) {
+                throw new InvalidFileImage();
+            }
             int originWidth = image.getWidth();
             int originHeight = image.getHeight();
             int targetWidth = 3300;
@@ -86,7 +95,7 @@ public class S3Service {
             return new MockMultipartFile(fileName, baos.toByteArray());
 
         } catch (IOException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 리사이즈에 실패했습니다.");
+            throw new failFileResize();
         }
     }
 }

--- a/backend/text-me/src/main/java/gifterz/textme/s3Proxy/exception/InvalidFileImage.java
+++ b/backend/text-me/src/main/java/gifterz/textme/s3Proxy/exception/InvalidFileImage.java
@@ -1,0 +1,10 @@
+package gifterz.textme.s3Proxy.exception;
+
+import gifterz.textme.error.ErrorCode;
+import gifterz.textme.error.exception.InvalidValueException;
+
+public class InvalidFileImage extends InvalidValueException {
+    public InvalidFileImage() {
+        super(ErrorCode.Illegal_FILE);
+    }
+}

--- a/backend/text-me/src/main/java/gifterz/textme/s3Proxy/exception/failFileResize.java
+++ b/backend/text-me/src/main/java/gifterz/textme/s3Proxy/exception/failFileResize.java
@@ -1,0 +1,10 @@
+package gifterz.textme.s3Proxy.exception;
+
+import gifterz.textme.error.ErrorCode;
+import gifterz.textme.error.exception.InvalidValueException;
+
+public class failFileResize extends InvalidValueException {
+    public failFileResize() {
+        super(ErrorCode.FAIL_FILE_RESIZE);
+    }
+}


### PR DESCRIPTION
`S3Service` 의 `resizeImage` 메서드에서 ImageIO.read() 메서드의 결과가 `null`일 경우 "업로드 할 수 없는 이미지입니다." 라는 에러 메시지를 출력하도록 수정